### PR TITLE
added setup_vim.sh

### DIFF
--- a/setup_vim.sh
+++ b/setup_vim.sh
@@ -1,0 +1,15 @@
+
+#!/bin/bash
+#
+# Set up line number in vim. Tested in Ubuntu and Mac. 
+#
+# Method of use:
+# source setup_vim.sh
+#
+
+
+echo "
+set number
+" >> ~/.vimrc
+
+echo ".vimrc updated"


### PR DESCRIPTION
This `setup_vim.sh` set the set number into `~/.vimrc` so that every time we open vim we get line numbers 